### PR TITLE
Able to have multiple roles on Sakai 10+ in LTI.is_role().

### DIFF
--- a/pylti/flask.py
+++ b/pylti/flask.py
@@ -161,7 +161,7 @@ class LTI(object):
         :param: role: role to verify against
         :return: if user is in role
         :exception: LTIException if role is unknown
-        """ 
+        """
         log.debug("is_role {}".format(role))
         roles = session['roles'].split(',')
         if role in LTI_ROLES:

--- a/pylti/flask.py
+++ b/pylti/flask.py
@@ -165,12 +165,12 @@ class LTI(object):
         log.debug("is_role {}".format(role))
         roles = session['roles'].split(',')
         if role in LTI_ROLES:
-            list = LTI_ROLES[role]
+            role_list = LTI_ROLES[role]
             # find the intersection of the roles
-            roles = set(LTI_ROLES[role]) & set(roles)
+            roles = set(role_list) & set(roles)
             is_user_role_there = len(roles) >= 1
             log.debug("is_role roles_list={} role={} in list={}"
-                      .format(list, roles, is_user_role_there))
+                      .format(role_list, roles, is_user_role_there))
             return is_user_role_there
         else:
             raise LTIException("Unknown role {}.".format(role))

--- a/pylti/flask.py
+++ b/pylti/flask.py
@@ -155,20 +155,23 @@ class LTI(object):
         return session['roles']
 
     def is_role(self, role):
-        """
+        """ 
         Verify if user is in role
 
         :param: role: role to verify against
         :return: if user is in role
         :exception: LTIException if role is unknown
-        """
+        """ 
         log.debug("is_role {}".format(role))
-        roles = session['roles']
+        roles = session['roles'].split(',')
         if role in LTI_ROLES:
             list = LTI_ROLES[role]
+            # find the intersection of the roles
+            roles = set(LTI_ROLES[role]) & set(roles)
+            is_user_role_there = len(roles) >= 1
             log.debug("is_role roles_list={} role={} in list={}"
-                      .format(list, roles, roles in list))
-            return roles in list
+                      .format(list, roles, is_user_role_there))
+            return is_user_role_there
         else:
             raise LTIException("Unknown role {}.".format(role))
 

--- a/pylti/flask.py
+++ b/pylti/flask.py
@@ -155,7 +155,7 @@ class LTI(object):
         return session['roles']
 
     def is_role(self, role):
-        """ 
+        """
         Verify if user is in role
 
         :param: role: role to verify against


### PR DESCRIPTION
I have an instance of Sakai 10+. I needed to create a list of the roles passed in from Sakai, and compare them against the list of applicable roles. I was only able to test this on my one instance, but it solved the issues I had.
The code still works if session['roles'] is a string of one role. Should be fully backwards compatible.