### PR TITLE
Coursera Compatibility

### DIFF
--- a/pylti/common.py
+++ b/pylti/common.py
@@ -40,7 +40,7 @@ LTI_ROLES = {
     u'instructor': [u'Instructor', ],
     u'administrator': [u'Administrator', ],
     u'student': [u'Student', u'Learner', ],
-    u'any': [u'Administrator', u'Instructor', u'Student', u'Learner',],
+    u'any': [u'Administrator', u'Instructor', u'Student', u'Learner', ],
 }
 
 LTI_SESSION_KEY = u'lti_authenticated'

--- a/pylti/tests/test_flask.py
+++ b/pylti/tests/test_flask.py
@@ -232,8 +232,13 @@ edge.edx.org-i4x-StarX-StarX_DEMO-lti-40559041895b4065b2818c23b9cd9da8\
         new_url = self.generate_launch_request(
             consumers, url, roles='Student'
         )
+        coursera_url = self.generate_launch_request(
+            consumers, url, roles='Learner'
+        )
 
         self.app.get(new_url)
+        self.assertTrue(self.has_exception())
+        self.app.get(coursera_url)
         self.assertTrue(self.has_exception())
 
     def test_access_to_oauth_resource_staff_only_as_administrator(self):


### PR DESCRIPTION
Coursera uses the "Learner" role for students, I'm adding this role to make PyLTI compatible with Coursera's LTI platform.