### PR TITLE
Bypass any role check for 'any'

### DIFF
--- a/pylti/common.py
+++ b/pylti/common.py
@@ -35,12 +35,13 @@ LTI_PROPERTY_LIST = [
     'lis_outcome_service_url'
 ]
 
+
 LTI_ROLES = {
     u'staff': [u'Administrator', u'Instructor', ],
     u'instructor': [u'Instructor', ],
     u'administrator': [u'Administrator', ],
-    u'student': [u'Student', u'Learner', ],
-    u'any': [u'Administrator', u'Instructor', u'Student', u'Learner', ],
+    u'student': [u'Student', u'Learner', ]
+    # There is also a special role u'any' that ignores role check
 }
 
 LTI_SESSION_KEY = u'lti_authenticated'

--- a/pylti/flask.py
+++ b/pylti/flask.py
@@ -198,7 +198,7 @@ class LTI(object):
         log.debug(
             "check_role lti_role=%s decorator_role=%s", self.role, role
         )
-        if not self.is_role(role):
+        if not (role == u'any' or self.is_role(role)):
             raise LTIRoleException('Not authorized.')
 
     @property

--- a/pylti/flask.py
+++ b/pylti/flask.py
@@ -160,7 +160,7 @@ class LTI(object):
 
         :return: roles
         """
-        return session['roles']
+        return session.get('roles')
 
     @staticmethod
     def is_role(role):

--- a/pylti/tests/test_flask.py
+++ b/pylti/tests/test_flask.py
@@ -343,7 +343,7 @@ edge.edx.org-i4x-StarX-StarX_DEMO-lti-40559041895b4065b2818c23b9cd9da8\
                   'lti_message_type': u'basic-lti-launch-request'}
 
         if roles is not None:
-          params['roles'] = roles
+            params['roles'] = roles
 
         if add_params is not None:
             params.update(add_params)
@@ -379,16 +379,15 @@ edge.edx.org-i4x-StarX-StarX_DEMO-lti-40559041895b4065b2818c23b9cd9da8\
         self.app.get(new_url)
         self.assertFalse(self.has_exception())
 
-
     def test_access_to_oauth_resource_any_nonstandard_role(self):
         """
         Test access to LTI protected resources.
         """
         url = 'http://localhost/any?'
-        new_url = self.generate_launch_request(self.consumers, url, roles=u'ThisIsNotAStandardRole')
+        new_url = self.generate_launch_request(self.consumers, url,
+                                               roles=u'ThisIsNotAStandardRole')
         self.app.get(new_url)
         self.assertFalse(self.has_exception())
-
 
     def test_access_to_oauth_resource_invalid(self):
         """

--- a/pylti/tests/test_flask.py
+++ b/pylti/tests/test_flask.py
@@ -324,7 +324,6 @@ edge.edx.org-i4x-StarX-StarX_DEMO-lti-40559041895b4065b2818c23b9cd9da8\
         params = {'resource_link_id': u'edge.edx.org-i4x-MITx-ODL_ENG-lti-'
                                       u'94173d3e79d145fd8ec2e83f15836ac8',
                   'user_id': u'008437924c9852377e8994829aaac7a1',
-                  'roles': roles,
                   'lis_result_sourcedid': u'MITx/ODL_ENG/2014_T1:'
                                           u'edge.edx.org-i4x-MITx-ODL_ENG-lti-'
                                           u'94173d3e79d145fd8ec2e83f15836ac8:'
@@ -342,6 +341,9 @@ edge.edx.org-i4x-StarX-StarX_DEMO-lti-40559041895b4065b2818c23b9cd9da8\
                                               u'/handler_noauth/'
                                               u'grade_handler'),
                   'lti_message_type': u'basic-lti-launch-request'}
+
+        if roles is not None:
+          params['roles'] = roles
 
         if add_params is not None:
             params.update(add_params)
@@ -367,6 +369,26 @@ edge.edx.org-i4x-StarX-StarX_DEMO-lti-40559041895b4065b2818c23b9cd9da8\
         new_url = self.generate_launch_request(self.consumers, url)
         self.app.get(new_url)
         self.assertFalse(self.has_exception())
+
+    def test_access_to_oauth_resource_any_norole(self):
+        """
+        Test access to LTI protected resources.
+        """
+        url = 'http://localhost/any?'
+        new_url = self.generate_launch_request(self.consumers, url, roles=None)
+        self.app.get(new_url)
+        self.assertFalse(self.has_exception())
+
+
+    def test_access_to_oauth_resource_any_nonstandard_role(self):
+        """
+        Test access to LTI protected resources.
+        """
+        url = 'http://localhost/any?'
+        new_url = self.generate_launch_request(self.consumers, url, roles=u'ThisIsNotAStandardRole')
+        self.app.get(new_url)
+        self.assertFalse(self.has_exception())
+
 
     def test_access_to_oauth_resource_invalid(self):
         """


### PR DESCRIPTION
Simple fix for #42 Draconian role checking