### PR TITLE
Add test data in the source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE
 include README.rst
 include pytest.ini
 include requirements.txt
+recursive-include pylti/tests/data *


### PR DESCRIPTION
Currently the source tarball on pypi misses the testing certificates, making it impossible to build and test from source.
This *should* fix the issue (untested yet).