### PR TITLE
Add setuptools to tests_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ try:
                                 "pytest-flakes>=0.2", "pytest>=2.6.3",
                                 "httpretty>=0.8.3", "flask>=0.10.1",
                                 "oauthlib>=0.6.3", "semantic_version>=2.3.1",
-                                "mock>=1.0.1"],
+                                "setuptools>=17.1", "mock>=1.0.1"],
                  cmdclass={"test": PyTest},
                  install_requires=["oauth>=1.0.1", "oauth2>=1.5.211",
                      "httplib2>=0.9" ],


### PR DESCRIPTION
In order to run the pylti tests, I needed to add
setuptools to setup.py to prevent this error:
https://github.com/testing-cabal/mock/issues/261