### PR TITLE
added 'ext_roles' as a standard LTI parameter. Roles are contained in…

### DIFF
--- a/pylti/common.py
+++ b/pylti/common.py
@@ -32,15 +32,23 @@ LTI_PROPERTY_LIST = [
     'lti_message',
     'lti_version',
     'roles',
+    'ext_roles',
     'lis_outcome_service_url'
 ]
 
 
 LTI_ROLES = {
-    u'staff': [u'Administrator', u'Instructor', ],
-    u'instructor': [u'Instructor', ],
-    u'administrator': [u'Administrator', ],
-    u'student': [u'Student', u'Learner', ]
+    u'staff': [u'Administrator',
+               u'Instructor',
+               u'urn:lti:instrole:ims/lis/Administrator'],
+    u'instructor': [u'Instructor',
+                    u'urn:lti:instrole:ims/lis/Instructor'],
+    u'administrator': [u'Administrator',
+                       u'urn:lti:instrole:ims/lis/Administrator',
+                       u'urn:lti:sysrole:ims/lis/SysAdmin'],
+    u'student': [u'Student', u'Learner',
+                 u'urn:lti:instrole:ims/lis/Learner',
+                 u'urn:lti:instrole:ims/lis/Student']
     # There is also a special role u'any' that ignores role check
 }
 

--- a/pylti/flask.py
+++ b/pylti/flask.py
@@ -34,6 +34,14 @@ def default_error(exception=None):
     return "There was an LTI communication error", 500
 
 
+def session_roles():
+    """
+    Return the full session roles which can be in 'roles' and 'ext_roles'
+    :return: roles
+    """
+    return ",".join((session.get('roles', ''), session.get('ext_roles', '')))
+
+
 class LTI(object):
     """
     LTI Object represents abstraction of current LTI session. It provides
@@ -160,7 +168,7 @@ class LTI(object):
 
         :return: roles
         """
-        return session.get('roles')
+        return session_roles()
 
     @staticmethod
     def is_role(role):
@@ -172,7 +180,7 @@ class LTI(object):
         :exception: LTIException if role is unknown
         """
         log.debug("is_role %s", role)
-        roles = session['roles'].split(',')
+        roles = session_roles().split(',')
         if role in LTI_ROLES:
             role_list = LTI_ROLES[role]
             # find the intersection of the roles

--- a/pylti/tests/test_flask.py
+++ b/pylti/tests/test_flask.py
@@ -254,6 +254,19 @@ edge.edx.org-i4x-StarX-StarX_DEMO-lti-40559041895b4065b2818c23b9cd9da8\
         self.app.get(new_url)
         self.assertFalse(self.has_exception())
 
+    def test_access_to_oauth_resource_staff_only_as_lti_administrator(self):
+        """
+        Allow access if user in role.
+        """
+        consumers = self.consumers
+        url = 'http://localhost/initial_staff?'
+        new_url = self.generate_launch_request(
+            consumers, url, roles='urn:lti:instrole:ims/lis/Administrator'
+        )
+
+        self.app.get(new_url)
+        self.assertFalse(self.has_exception())
+
     def test_access_to_oauth_resource_staff_only_as_unknown_role(self):
         """
         Deny access if role not defined.
@@ -287,12 +300,42 @@ edge.edx.org-i4x-StarX-StarX_DEMO-lti-40559041895b4065b2818c23b9cd9da8\
         self.app.get(student_url)
         self.assertFalse(self.has_exception())
 
+    def test_access_to_oauth_resource_student_as_lti_student(self):
+        """
+        Verify that the various roles we consider as students are students.
+        """
+        consumers = self.consumers
+        url = 'http://localhost/initial_student?'
+
+        # Learner Role
+        learner_url = self.generate_launch_request(
+            consumers, url, roles='urn:lti:instrole:ims/lis/Learner'
+        )
+        self.app.get(learner_url)
+        self.assertFalse(self.has_exception())
+
+        student_url = self.generate_launch_request(
+            consumers, url, roles='urn:lti:instrole:ims/lis/Student'
+        )
+        self.app.get(student_url)
+        self.assertFalse(self.has_exception())
+
     def test_access_to_oauth_resource_student_as_staff(self):
         """Verify staff doesn't have access to student only."""
         consumers = self.consumers
         url = 'http://localhost/initial_unknown?'
         staff_url = self.generate_launch_request(
             consumers, url, roles='Staff'
+        )
+        self.app.get(staff_url)
+        self.assertTrue(self.has_exception())
+
+    def test_access_to_oauth_resource_student_as_lti_staff(self):
+        """Verify staff doesn't have access to student only."""
+        consumers = self.consumers
+        url = 'http://localhost/initial_unknown?'
+        staff_url = self.generate_launch_request(
+            consumers, url, roles='urn:lti:instrole:ims/lis/Administrator'
         )
         self.app.get(staff_url)
         self.assertTrue(self.has_exception())


### PR DESCRIPTION
… this parameter.

Added full LTI role names to LTI_ROLES. Many LMS implementations will send roles this way.
Created session_roles function to return the combined roles that can come from 'roles' or 'ext_roles' launch parameters.
Added tests to accommodate for the full LTI roles.