### PR TITLE
added url as a parameter to allow user to set the url directly, becau…

### DIFF
--- a/pylti/flask.py
+++ b/pylti/flask.py
@@ -327,7 +327,7 @@ class LTI(object):
         session[LTI_SESSION_KEY] = False
 
 
-def lti(app=None, request='any', error=default_error, role='any',
+def lti(app=None, request='any', error=default_error, role='any',url=None,
         *lti_args, **lti_kwargs):
     """
     LTI decorator
@@ -356,6 +356,8 @@ def lti(app=None, request='any', error=default_error, role='any',
             Pass LTI reference to function or return error.
             """
             try:
+                if url:
+                    flask_request.url = url
                 the_lti = LTI(lti_args, lti_kwargs)
                 the_lti.verify()
                 the_lti._check_role()  # pylint: disable=protected-access


### PR DESCRIPTION
Added url as a parameter to allow user to set the url directly, because oauth requires the exact url that LTI used, but the url can be changed by a redirect, rewrite, proxy, ssl offload, or etc.

For example, the LTI consumer might use https://foo.bar.com, but your app might be behind a load balancer, so url by the time it gets to the Flask app is http://server1.foo.bar.com:8443/

I had tried to make a decorator to do this, but was pretty complex.  This approach is easier and will be commonly needed by LTI users anyways.