### PR TITLE
Fix automated tests by limiting pytest to version 2.6.4

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 pytest-cov>=1.8.0
 pytest-pep8>=1.0.6
 pytest-flakes>=0.2
-pytest>=2.6.3
+pytest==2.6.4
 httpretty>=0.8.3
 flask>=0.10.1
 oauthlib>=0.6.3


### PR DESCRIPTION
https://github.com/mitodl/pylti/issues/58