### PR TITLE
Add setup.cfg to allow universal wheel building (py2 + py3)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
When you create a wheel file with

    ./ve/bin/python setup.py build bdist_wheel

The created wheel file is made for either python 2 or 3, depending on
your current setup. This change enables creation of a py2-py3 wheel file.