### PR TITLE
Update oauthlib to 2.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==0.10.1
 httpretty==0.8.3
 oauth2==1.9.0.post1
-oauthlib==0.6.3
+oauthlib==2.0.6
 pyflakes==1.2.3
 pytest==2.9.2
 pytest-cache==1.0


### PR DESCRIPTION
oauthlib 0.6.3 is old (from 2014). oauthlib is only used for testing purposes in pylti. I've updated to 2.0.6 and tests pass, so we might as well update.