### PR TITLE
Fix pylti for Django behind a TLS termination proxy

### DIFF
--- a/pylti/common.py
+++ b/pylti/common.py
@@ -280,7 +280,12 @@ def verify_request_common(consumers, url, method, headers, params):
         SignatureMethod_HMAC_SHA1_Unicode())
 
     # Check header for SSL before selecting the url
-    if headers.get('X-Forwarded-Proto', 'http') == 'https':
+    if (
+        headers.get(
+            "X-Forwarded-Proto",
+            headers.get("HTTP_X_FORWARDED_PROTO", "http"),
+        ) == "https"
+    ):
         url = url.replace('http:', 'https:', 1)
 
     oauth_request = Request_Fix_Duplicate.from_request(

--- a/pylti/tests/test_common.py
+++ b/pylti/tests/test_common.py
@@ -143,6 +143,22 @@ edge.edx.org-i4x-StarX-StarX_DEMO-lti-40559041895b4065b2818c23b9cd9da8\
                                     headers, verify_params)
         self.assertTrue(ret)
 
+    def test_verify_request_common_via_proxy_wsgi_syntax(self):
+        """
+        verify_request_common succeeds on valid request via proxy with
+        wsgi syntax for headers
+        """
+        headers = dict()
+        headers['HTTP_X_FORWARDED_PROTO'] = 'https'
+        orig_url = 'https://localhost:5000/?'
+        consumers, method, url, verify_params, _ = (
+            self.generate_oauth_request(url_to_sign=orig_url)
+        )
+
+        ret = verify_request_common(consumers, url, method,
+                                    headers, verify_params)
+        self.assertTrue(ret)
+
     def test_verify_request_common_no_oauth_fields(self):
         """
         verify_request_common fails on missing authentication


### PR DESCRIPTION
## Purpose

WSGI servers format their headers by prefixing them with HTTP_, capitalizing all letters and replacing "-" by "_". The Django framework is using this format for its headers.

Pylti is checking the value of the "X-Forwarded-Proto" header with the http syntax and is missing it when the http header is named "HTTP_X_FORWARDED_PROTO" as is the case in Django for example.

## Proposal

Look for the header successively with both syntaxes "X-Forwarded-Proto" and "HTTP_X_FORWARDED_PROTO" so we directly support the wsgi syntax for headers.
