### PR TITLE
Make LTIBase.is_role() an instance method

### DIFF
--- a/pylti/common.py
+++ b/pylti/common.py
@@ -546,7 +546,6 @@ class LTIBase(object):
         """
         return self.session.get('roles')
 
-    @staticmethod
     def is_role(self, role):
         """
         Verify if user is in role


### PR DESCRIPTION
#### What are the relevant tickets?
None.

#### What does this PR do?
This PR proposes to remove `@staticmethod` from the definition of `is_role()` of LTIBase class.

#### How should this be manually tested?
We can check if the call `lti.is_role("role-name-here")` is possible or not.

#### Where should the reviewer start?
https://github.com/yuttie/pylti/blob/make-is_role-instance-method/pylti/common.py#L549

#### Any background context you want to provide?
Since the signature of the method includes `self`, I believe this method was mistakenly marked as a static method.